### PR TITLE
Fixed static asset copy from being too greedy

### DIFF
--- a/src/TinyMCE.Umbraco.Client/vite.config.ts
+++ b/src/TinyMCE.Umbraco.Client/vite.config.ts
@@ -6,11 +6,11 @@ export const plugins: PluginOption[] = [
 	viteStaticCopy({
 		targets: [
 			{
-				src: 'node_modules/tinymce/**/*',
+				src: 'node_modules/tinymce/*',
 				dest: 'lib',
 			},
 			{
-				src: 'node_modules/tinymce-i18n/langs6/**/*',
+				src: 'node_modules/tinymce-i18n/langs6/*',
 				dest: 'lib/langs',
 			},
 		],


### PR DESCRIPTION
I'd noticed in the "App_Plugins/TinyMCE/lib" folder that the TinyMCE library sub-folders being copied over twice; once in the correct folder structure, then another in a flattened structure.  It turns out that the glob pattern I'd used in the `vite.config.ts` was a bit too greedy, causing much filesize bloat in the App_Plugins folder (and NuGet package).

This fix should reduce the NuGet package filesize by about 2Mb.