### PR TITLE
V16/task/marketplace specific meta

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -29,7 +29,7 @@ If you are upgrading from Umbraco version 15, install this package before beginn
 
 ### Looking for the v13 version?
 
-You can find the v13 version on [Nuget as TinyMCE.Umbraco.Premium](https://www.nuget.org/packages/tinymce.umbraco.premium/).  Also, the documentation is available as a Readme on the [v13/main branch here on Github](https://github.com/ProWorksCorporation/TinyMCE-Umbraco/tree/v13/main).
+You can find the v13 version on [NuGet as TinyMCE.Umbraco.Premium](https://www.nuget.org/packages/tinymce.umbraco.premium/).  Also, the documentation is available as a Readme on the [v13/main branch here on Github](https://github.com/ProWorksCorporation/TinyMCE-Umbraco/tree/v13/main).
 
 # Documentation
 
@@ -39,7 +39,7 @@ To get started with the TinyMCE Umbraco property editor and use it with your pro
 
 The following options are available for configuration in the `appsettings.json` or through other environment level configuration settings (`web.config`, Azure environment variables, etc).  This is using standard .NET configuration and you can learn more about [.NET Configuration here](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-8.0).
 
-### Umbraco CMS RichTextEditor Configuration Retained
+### Umbraco CMS RichTextEditor configuration retained
 
 The traditional Umbraco CMS TinyMCE Configuration settings continue to function as expected.  The Umbraco Documentation has a good example of the configuration options and how they can be set here: [Rich text editor settings](https://docs.umbraco.com/umbraco-cms/13.latest/reference/configuration/richtexteditorsettings).
 
@@ -209,6 +209,7 @@ The initial source code has been derived from [Umbraco CMS](https://github.com/u
 ## Acknowledgments
 
 Thanks to [TinyMCE](https://www.tiny.cloud/) and [Umbraco](https://umbraco.com/) for their support during the package development.
+
 Special thanks to [Lee Kelleher](https://github.com/leekelleher) and [Jacob Overgaard](https://github.com/iOvergaard) for their contributions, help getting started, and for giving valuable feedback along the way.
 
 Also thanks to the [ProWorks](https://www.proworks.com) team for their encouragement, support, and contributions.

--- a/umbraco-marketplace-readme-tinymce.umbraco.premium.md
+++ b/umbraco-marketplace-readme-tinymce.umbraco.premium.md
@@ -1,0 +1,11 @@
+# TinyMCE Premium package for Umbraco CMS package
+This is an Umbraco CMS package that enables access to the paid features in the TinyMCE-based Rich Text Editor (RTE) in version 12+ with a license. It also adds a new TinyMCE Premium property editor with additional settings, providing a more targeted configuration setup for RTE Data Types in Umbraco. Finally, it allows for additional settings that support JSON directly in the configuration for .NET (appsettings.config).
+
+The TinyMCE Umbraco Premium package works with Umbraco versions 12, and 13
+
+* v12.x Supports Umbraco CMS version 12+
+* v13.x Supports Umbraco CMS version 13+
+
+You can find Documentation on how to setup, configure, and customize the TinyMCE Premium editor in the [GitHub repository](https://github.com/ProWorksCorporation/TinyMCE-Umbraco)
+
+For support requests about TinyMCE Premium, please [contact Tiny support](https://support.tiny.cloud/)

--- a/umbraco-marketplace-readme.md
+++ b/umbraco-marketplace-readme.md
@@ -1,11 +1,7 @@
 # TinyMCE package for Umbraco CMS
 This Umbraco CMS package enables access to the TinyMCE-based Rich Text Editor (RTE) in version 16 and above. It also supports the use of TinyMCE Premium plugins with a valid subscription. Additional features include streamlined configuration for RTE Data Types in Umbraco and enhanced settings that support direct JSON-based configuration via .NET (appsettings.config).
 
-The TinyMCE Umbraco package Works with Umbraco Versions 12, 13, and 16
-
-* v12.x Supports Umbraco CMS version 12+
-* v13.x Supports Umbraco CMS version 13+
-* v16.x Supports Umbraco CMS version 16+
+The TinyMCE Umbraco package works with Umbraco 16+
 
 You can find Documentation on how to setup, configure, and customize the TinyMCE Premium editor in the [Github repository](https://github.com/ProWorksCorporation/TinyMCE-Umbraco)
 

--- a/umbraco-marketplace-tinymce.umbraco.premium.json
+++ b/umbraco-marketplace-tinymce.umbraco.premium.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://marketplace.umbraco.com/umbraco-marketplace-schema.json",
+  "AddOnPackagesRequiredForUmbracoCloud": [],
+  "AlternateCategory": "Artificial Intelligence",
+  "AuthorDetails": {
+    "Name": "ProWorks Corporation",
+    "Description": "ProWorks Corporation is an Umbraco Platinum Partner and Contributing Partner with a long-standing commitment to the Umbraco community. As a web design and development agency, ProWorks helps bridge the gap between marketing and IT teams, and delivers creative solutions to complex challenges.",
+    "Url": "https://www.proworks.com/",
+    "ImageUrl": "https://github.com/ProWorksCorporation.png",
+    "Contributors": [],
+    "SyncContributorsFromRepository": false
+  },
+  "Category": "Editor Tools",
+  "Description": "Access all the paid features and plugins that TinyMCE offers such as the Accessibility Checker, AI Assistant, Templating, and more.",
+  "DiscussionForumUrl": "https://github.com/ProWorksCorporation/TinyMCE-Umbraco/issues",
+  "DocumentationUrl": "https://github.com/ProWorksCorporation/TinyMCE-Umbraco",
+  "LicenseTypes": ["Free"],
+  "IssueTrackerUrl": "https://github.com/ProWorksCorporation/TinyMCE-Umbraco/issues",
+  "IsSubPackageOf": "",
+  "PackageType": "Package",
+  "Title": "TinyMCE Premium",
+  "LookingForContributors": true,
+  "LookingForMaintainer": false,
+  "PackagesByAuthor": [],
+  "RelatedPackages": [],
+  "Screenshots": [
+    {
+      "ImageUrl": "https://www.proworks.com/media/gejlaa3o/createnewdatatype-tiny.png",
+      "Caption": "TinyMCE Premium Property Editor"
+    },
+    {
+      "ImageUrl": "https://www.proworks.com/media/msgnyacf/aiassistant_content_2.png",
+      "Caption": "AI Assistant"
+    },
+    {
+      "ImageUrl": "https://www.proworks.com/media/spihem3m/customconfig_templates.png",
+      "Caption": "Advanced Templates"
+    }
+  ],
+  "Tags": [
+    "backoffice",
+    "rich text editor",
+    "tinymce",
+    "editorial experience",
+    "property editor",
+  ],
+  "VersionSpecificPackageIds": [
+    {
+      "UmbracoMajorVersion": 12,
+      "PackageId": "tinymce.umbraco.premium"
+    },
+    {
+      "UmbracoMajorVersion": 13,
+      "PackageId": "tinymce.umbraco.premium"
+    {
+      "UmbracoMajorVersion": 16,
+      "PackageId": "tinymce.umbraco"
+    }
+  ],
+  "VideoUrl": ""
+}

--- a/umbraco-marketplace.json
+++ b/umbraco-marketplace.json
@@ -1,61 +1,61 @@
 {
-    "$schema": "https://marketplace.umbraco.com/umbraco-marketplace-schema.json", 
-    "AlternateCategory": "Artificial Intelligence",
-    "AuthorDetails": {
-      "Name": "ProWorks Corporation",
-      "Description": "ProWorks Corporation is an Umbraco Platinum Partner and Contributing Partner with a long-standing commitment to the Umbraco community. As a web design and development agency, ProWorks helps bridge the gap between marketing and IT teams, and delivers creative solutions to complex challenges.",
-      "Url": "https://www.proworks.com/",
-      "ImageUrl": "https://github.com/ProWorksCorporation.png",
-      "Contributors": [],
-      "SyncContributorsFromRepository": false
+  "$schema": "https://marketplace.umbraco.com/umbraco-marketplace-schema.json",
+  "AlternateCategory": "Artificial Intelligence",
+  "AuthorDetails": {
+    "Name": "ProWorks Corporation",
+    "Description": "ProWorks Corporation is an Umbraco Platinum Partner and Contributing Partner with a long-standing commitment to the Umbraco community. As a web design and development agency, ProWorks helps bridge the gap between marketing and IT teams, and delivers creative solutions to complex challenges.",
+    "Url": "https://www.proworks.com/",
+    "ImageUrl": "https://github.com/ProWorksCorporation.png",
+    "Contributors": [],
+    "SyncContributorsFromRepository": false
+  },
+  "Category": "Editor Tools",
+  "Description": "This Umbraco CMS package enables access to the TinyMCE-based Rich Text Editor (RTE) in version 16 and above. It also supports the use of TinyMCE Premium plugins with a valid subscription. Additional features include streamlined configuration for RTE Data Types in Umbraco and enhanced settings that support direct JSON-based configuration via .NET (appsettings.config).",
+  "DiscussionForumUrl": "https://github.com/ProWorksCorporation/TinyMCE-Umbraco/issues",
+  "DocumentationUrl": "https://github.com/ProWorksCorporation/TinyMCE-Umbraco",
+  "LicenseTypes": ["Free"],
+  "IssueTrackerUrl": "https://github.com/ProWorksCorporation/TinyMCE-Umbraco/issues",
+  "IsSubPackageOf": "",
+  "PackageType": "Package",
+  "Title": "TinyMCE",
+  "LookingForContributors": true,
+  "LookingForMaintainer": false,
+  "PackagesByAuthor": [],
+  "RelatedPackages": [],
+  "Screenshots": [
+    {
+      "ImageUrl": "https://www.proworks.com/media/gejlaa3o/createnewdatatype-tiny.png",
+      "Caption": "TinyMCE Property Editor"
     },
-    "Category": "Editor Tools",
-    "Description": "This Umbraco CMS package enables access to the TinyMCE-based Rich Text Editor (RTE) in version 16 and above. It also supports the use of TinyMCE Premium plugins with a valid subscription. Additional features include streamlined configuration for RTE Data Types in Umbraco and enhanced settings that support direct JSON-based configuration via .NET (appsettings.config).",
-    "DiscussionForumUrl": "https://github.com/ProWorksCorporation/TinyMCE-Umbraco/issues",
-    "DocumentationUrl": "https://github.com/ProWorksCorporation/TinyMCE-Umbraco",
-    "LicenseTypes": [ "Free" ],
-    "IssueTrackerUrl": "https://github.com/ProWorksCorporation/TinyMCE-Umbraco/issues",
-    "IsSubPackageOf": "",
-    "PackageType": "Package",
-    "Title": "TinyMCE for Umbraco CMS",
-    "LookingForContributors": true,
-    "LookingForMaintainer": false,
-    "PackagesByAuthor": [],
-    "RelatedPackages": [],
-    "Screenshots": [
-      {
-        "ImageUrl": "https://www.proworks.com/media/gejlaa3o/createnewdatatype-tiny.png",
-        "Caption": "TinyMCE Property Editor"
-      },
-      {
-        "ImageUrl": "https://www.proworks.com/media/msgnyacf/aiassistant_content_2.png",
-        "Caption": "AI Assistant"
-      },
-      {
-        "ImageUrl": "https://www.proworks.com/media/spihem3m/customconfig_templates.png",
-        "Caption": "Advanced Templates"
-      }
-    ],
-    "Tags": [
-      "backoffice",
-      "rich text editor",
-      "tinymce",
-      "editorial experience",
-      "property editor"
-    ],
-    "VersionSpecificPackageIds": [
-      {
-        "UmbracoMajorVersion": 12,
-        "PackageId": "tinymce.umbraco.premium"
-      },
-      {
-        "UmbracoMajorVersion": 13,
-        "PackageId": "tinymce.umbraco.premium"
-      },
-      {
-        "UmbracoMajorVersion": 16,
-        "PackageId": "tinymce.umbraco"
-      }
-    ],
-    "VideoUrl": ""
+    {
+      "ImageUrl": "https://www.proworks.com/media/msgnyacf/aiassistant_content_2.png",
+      "Caption": "AI Assistant"
+    },
+    {
+      "ImageUrl": "https://www.proworks.com/media/spihem3m/customconfig_templates.png",
+      "Caption": "Advanced Templates"
+    }
+  ],
+  "Tags": [
+    "backoffice",
+    "rich text editor",
+    "tinymce",
+    "editorial experience",
+    "property editor"
+  ],
+  "VersionSpecificPackageIds": [
+    {
+      "UmbracoMajorVersion": 12,
+      "PackageId": "tinymce.umbraco.premium"
+    },
+    {
+      "UmbracoMajorVersion": 13,
+      "PackageId": "tinymce.umbraco.premium"
+    },
+    {
+      "UmbracoMajorVersion": 16,
+      "PackageId": "tinymce.umbraco"
+    }
+  ],
+  "VideoUrl": ""
 }


### PR DESCRIPTION
I'd noticed on the Marketplace that both of the packages are sharing the same meta-data, making them appear as duplicates.

- https://marketplace.umbraco.com/package/tinymce.umbraco
- https://marketplace.umbraco.com/package/tinymce.umbraco.premium

The reason for this is that both NuGet packages are pointing to the same URL for the "Package information", (which is fine), but the Marketplace is reading the meta-data from the `umbraco-marketplace.json`, which is causing the appearance of duplication.

The simplest way to resolve this is to have a package-specific manifest (and readme) for the v13/Premium version.
_(There is more info about this on the [Package Listing for the Marketplace](https://docs.umbraco.com/umbraco-dxp/marketplace/listing-your-package#additional-package-information) docs)._

I have copied over the meta-data from the `v13/main` branch, and updated the v16 manifest/readme accordingly.

