### PR TITLE
Adds "TinyMCE" to the `propertyEditorUi` manifest's name

### DIFF
--- a/src/TinyMCE.Umbraco.Client/src/property-editors/tiny-mce/manifests.ts
+++ b/src/TinyMCE.Umbraco.Client/src/property-editors/tiny-mce/manifests.ts
@@ -5,7 +5,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 	{
 		type: 'propertyEditorUi',
 		alias: UMB_BLOCK_RTE_PROPERTY_EDITOR_UI_ALIAS,
-		name: 'Rich Text Editor Property Editor UI',
+		name: 'Rich Text Editor [TinyMCE] Property Editor UI',
 		element: () => import('./property-editor-ui-tiny-mce.element.js'),
 		meta: {
 			label: 'Rich Text Editor [TinyMCE]',


### PR DESCRIPTION
> [!NOTE]
> This is a minor tweak, no urgency in merging in or releasing.

Adds "[TinyMCE]" to the `propertyEditorUi` manifest's name.

I'd noticed in the Extension Insights section that the name of the property-editor manifest was just "Rich Text Editor Property Editor UI" and didn't mention TinyMCE. So not to confuse between Umbraco core's RTE manifest name, I thought it good to add `[TinyMCE]` into the name. This is a very minor tweak.